### PR TITLE
Add support for trace files from WebPagetest

### DIFF
--- a/lib/timeline-model.js
+++ b/lib/timeline-model.js
@@ -61,9 +61,14 @@ class SandboxedModel {
     // timeline model
     this._timelineModel = new WebInspector.TimelineModel(WebInspector.TimelineUIUtils.visibleEventsFilter())
 
+    // convert string (e.g. via fs.readFileSync) to JS
+    if (typeof events === 'string') events = JSON.parse(events)
+    // WebPagetest trace files put events in object under key `traceEvents`
+    if (events.hasOwnProperty('traceEvents')) events = events.traceEvents
+
     // populate with events
     this._tracingModel.reset()
-    this._tracingModel.addEvents(typeof events === 'string' ? JSON.parse(events) : events)
+    this._tracingModel.addEvents(events)
     this._tracingModel.tracingComplete()
     this._timelineModel.setEvents(this._tracingModel)
 


### PR DESCRIPTION
WebPagetest trace files are in the form `{traceEvents: Array<Object>}` (e.g. [this trace file][trace] from [this test run][results]), while `WebInspector.TracingModel.prototype.addEvents` expects `Array<Object>`.

If `traceEvents` key is present, pass the value (array of objects) instead of the entire object.

See `traceEvents` added & removed throughout WPT [here](https://github.com/WPO-Foundation/webpagetest/search?utf8=%E2%9C%93&q=traceEvents)

Glad to add a fixture for WPT trace file and ensure it passes existing tests. Could also add a check like `if (!Array.isArray(events)) throw Error('events must be an array')`

[results]: http://www.webpagetest.org/result/160411_RD_14CB/
[trace]: http://www.webpagetest.org/getgzip.php?test=160411_RD_14CB&file=1_trace.json