### PR TITLE
bump to latest devtools-frontend

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,8 +5,7 @@ var vm = require('vm');
 
 /* eslint-disable no-native-reassign */
 if (typeof __dirname === 'undefined') {
-  process = process || {};
-  __dirname = {};
+  __dirname = '';
 }
 /* eslint-enable no-native-reassign */
 
@@ -16,7 +15,7 @@ class ModelAPI {
 
     // Everything happens in a sandboxed vm context, to keep globals and natives separate.
     // First, sandboxed contexts don't have any globals from node, so we whitelist a few we'll provide for it.
-    var glob = {require: require, global: global, console: console, process: process, __dirname: __dirname};
+    var glob = {require: require, global: global, console: console, __dirname: __dirname};
     // We read in our script to run, and create a vm.Script object
     /* eslint-disable no-path-concat */
     var script = new vm.Script(fs.readFileSync(__dirname + '/lib/timeline-model.js', 'utf8'));

--- a/lib/timeline-model.js
+++ b/lib/timeline-model.js
@@ -27,27 +27,28 @@ requireval('./lib/api-stubs.js');
 
 // chrome devtools frontend
 requireval('chrome-devtools-frontend/front_end/common/Object.js');
-requireval('chrome-devtools-frontend/front_end/common/SegmentedRange.js');
 requireval('chrome-devtools-frontend/front_end/platform/utilities.js');
 requireval('chrome-devtools-frontend/front_end/sdk/Target.js');
+requireval('chrome-devtools-frontend/front_end/common/SegmentedRange.js');
 requireval('chrome-devtools-frontend/front_end/bindings/TempFile.js');
 requireval('chrome-devtools-frontend/front_end/sdk/TracingModel.js');
-requireval('chrome-devtools-frontend/front_end/timeline/TimelineJSProfile.js');
+requireval('chrome-devtools-frontend/front_end/sdk/ProfileTreeModel.js');
 requireval('chrome-devtools-frontend/front_end/timeline/TimelineUIUtils.js');
+requireval('chrome-devtools-frontend/front_end/timeline_model/TimelineJSProfile.js');
 requireval('chrome-devtools-frontend/front_end/sdk/CPUProfileDataModel.js');
-requireval('chrome-devtools-frontend/front_end/timeline/LayerTreeModel.js');
-requireval('chrome-devtools-frontend/front_end/timeline/TimelineModel.js');
-requireval('chrome-devtools-frontend/front_end/timeline/TimelineTreeView.js');
+requireval('chrome-devtools-frontend/front_end/timeline_model/LayerTreeModel.js');
+requireval('chrome-devtools-frontend/front_end/timeline_model/TimelineModel.js');
 requireval('chrome-devtools-frontend/front_end/ui_lazy/SortableDataGrid.js');
-requireval('chrome-devtools-frontend/front_end/timeline/TimelineProfileTree.js');
+requireval('chrome-devtools-frontend/front_end/timeline/TimelineTreeView.js');
+requireval('chrome-devtools-frontend/front_end/timeline_model/TimelineProfileTree.js');
 requireval('chrome-devtools-frontend/front_end/components_lazy/FilmStripModel.js');
-requireval('chrome-devtools-frontend/front_end/timeline/TimelineIRModel.js');
-requireval('chrome-devtools-frontend/front_end/timeline/TimelineFrameModel.js');
+requireval('chrome-devtools-frontend/front_end/timeline_model/TimelineIRModel.js');
+requireval('chrome-devtools-frontend/front_end/timeline_model/TimelineFrameModel.js');
 
 // minor configurations
 requireval('./lib/devtools-monkeypatches.js');
 // polyfill the bottom-up and topdown tree sorting
-const TreeView = require('./lib/timeline-model-treeview.js')(WebInspector);
+const TimelineModelTreeView = require('./lib/timeline-model-treeview.js')(WebInspector);
 
 class SandboxedModel {
 
@@ -61,21 +62,21 @@ class SandboxedModel {
     // timeline model
     this._timelineModel = new WebInspector.TimelineModel(WebInspector.TimelineUIUtils.visibleEventsFilter());
 
-    // convert string (e.g. via fs.readFileSync) to JS
     if (typeof events === 'string') events = JSON.parse(events);
     // WebPagetest trace files put events in object under key `traceEvents`
     if (events.hasOwnProperty('traceEvents')) events = events.traceEvents;
 
     // populate with events
     this._tracingModel.reset();
-    this._tracingModel.addEvents(typeof events === 'string' ? JSON.parse(events) : events);
+    this._tracingModel.addEvents(events);
     this._tracingModel.tracingComplete();
     this._timelineModel.setEvents(this._tracingModel);
 
-    this._aggregator = new WebInspector.TimelineAggregator(event =>
-      WebInspector.TimelineUIUtils.eventStyle(event).category.name);
-
     return this;
+  }
+
+  _createAggregator() {
+    return WebInspector.AggregatedTimelineTreeView.prototype._createAggregator();
   }
 
   timelineModel() {
@@ -97,14 +98,15 @@ class SandboxedModel {
     ];
     filters.push(new WebInspector.ExclusiveNameFilter(nonessentialEvents));
 
-    return WebInspector.TimelineProfileTree.buildTopDown(this._timelineModel.mainThreadEvents(),
-                  filters, /* startTime */ 0, /* endTime */ Infinity, WebInspector.TimelineAggregator.eventId);
+    var topDown = WebInspector.TimelineProfileTree.buildTopDown(this._timelineModel.mainThreadEvents(),
+      filters, /* startTime */ 0, /* endTime */ Infinity, WebInspector.TimelineAggregator.eventId);
+    return topDown;
   }
 
   bottomUp() {
     var topDown = this.topDown();
     var noGrouping = WebInspector.TimelineAggregator.GroupBy.None;
-    var noGroupAggregator = this._aggregator.groupFunction(noGrouping);
+    var noGroupAggregator = this._createAggregator().groupFunction(noGrouping);
     return WebInspector.TimelineProfileTree.buildBottomUp(topDown, noGroupAggregator);
   }
 
@@ -116,18 +118,20 @@ class SandboxedModel {
     var topDown = this.topDown();
 
     var groupSetting = WebInspector.TimelineAggregator.GroupBy[grouping];
-    var groupingAggregator = this._aggregator.groupFunction(groupSetting);
+    var groupingAggregator = this._createAggregator().groupFunction(groupSetting);
     var bottomUpGrouped = WebInspector.TimelineProfileTree.buildBottomUp(topDown, groupingAggregator);
 
     // sort the grouped tree, in-place
-    new TreeView(bottomUpGrouped).sortingChanged('self', 'desc');
+    new TimelineModelTreeView(bottomUpGrouped).sortingChanged('self', 'desc');
     return bottomUpGrouped;
   }
 
   frameModel() {
-    var frameModel = new WebInspector.TracingTimelineFrameModel();
-    frameModel.addTraceEvents({ /* target */ }, this._timelineModel.inspectedTargetEvents(),
-      this._timelineModel.sessionId() || '');
+    var frameModel = new WebInspector.TimelineFrameModel(event =>
+      WebInspector.TimelineUIUtils.eventStyle(event).category.name
+    );
+    frameModel.addTraceEvents({ /* target */ },
+      this._timelineModel.inspectedTargetEvents(), this._timelineModel.sessionId() || '');
     return frameModel;
   }
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "timeline"
   ],
   "dependencies": {
-    "chrome-devtools-frontend": "1.0.382117",
+    "chrome-devtools-frontend": "1.0.401423",
     "resolve": "1.1.7"
   },
   "devDependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -58,32 +58,32 @@ describe('DevTools Timeline Model', function() {
   });
 
   it('metrics returned are expected', () => {
-    assert.equal(model.timelineModel().mainThreadEvents().length, 7228);
+    assert.equal(model.timelineModel().mainThreadEvents().length, 7756);
     assert.equal(model.interactionModel().interactionRecords().length, 0);
     assert.equal(model.frameModel().frames().length, 16);
   });
 
   it('top-down profile', () => {
     const leavesCount = model.topDown().children.size;
-    assert.equal(leavesCount, 28);
+    assert.equal(leavesCount, 27);
     const time = model.topDown().totalTime.toFixed(2);
-    assert.equal(time, '559.21');
+    assert.equal(time, '555.01');
   });
 
   it('bottom-up profile', () => {
     const leavesCount = model.bottomUp().children.size;
-    assert.equal(leavesCount, 243);
+    assert.equal(leavesCount, 242);
     const topCosts = [...model.bottomUpGroupBy('URL').children.values()];
     const time = topCosts[1].totalTime.toFixed(2);
     const url = topCosts[1].id;
-    assert.equal(time, '80.77');
+    assert.equal(time, '76.26');
     assert.equal(url, 'https://s.ytimg.com/yts/jsbin/www-embed-lightweight-vflu_2b1k/www-embed-lightweight.js');
   });
 
   it('bottom-up profile - group by eventname', () => {
     const bottomUpByName = model.bottomUpGroupBy('EventName');
     const leavesCount = bottomUpByName.children.size;
-    assert.equal(leavesCount, 15);
+    assert.equal(leavesCount, 14);
     const topCosts = [...bottomUpByName.children.values()];
     const time = topCosts[0].selfTime.toFixed(2);
     const name = topCosts[0].id;


### PR DESCRIPTION
There were some recent updates to the profiletree. This is the juiciest diff of old v new.

![image](https://cloud.githubusercontent.com/assets/39191/16321945/c63b92f8-3997-11e6-850b-5ca46707e540.png)


Due to some changes in DOMGC event names, the old frontend doesnt handle new traces as well, and the numbers change a bit.

