### PR TITLE
Add missing console import

### DIFF
--- a/lib/timeline-model.js
+++ b/lib/timeline-model.js
@@ -76,6 +76,7 @@ requireval('./lib/api-stubs.js');
 
 // chrome devtools frontend
 requireval('chrome-devtools-frontend/front_end/common/Object.js');
+requireval('chrome-devtools-frontend/front_end/common/Console.js');
 requireval('chrome-devtools-frontend/front_end/platform/utilities.js');
 requireval('chrome-devtools-frontend/front_end/common/ParsedURL.js');
 requireval('chrome-devtools-frontend/front_end/common/UIString.js');


### PR DESCRIPTION
## Problem

The `TimelineModel` class uses `Common.console.error` which is not accessible due to missing imports. When I was trying to create an instance of the `DevtoolsTimelineModel` class I received the following error:

```
TypeError: Cannot read property 'error' of undefined
    at TimelineModel.TimelineModel._processMetadataEvents (chrome-devtools-frontend/front_end/timeline_model/TimelineModel.js:268:21)
    at TimelineModel.TimelineModel.setEvents (chrome-devtools-frontend/front_end/timeline_model/TimelineModel.js:175:31)
    at SandboxedModel.init (evalmachine.<anonymous>:134:25)
    at new ModelAPI (/.../node_modules/devtools-timeline-model/index.js:29:18)
    at Object.<anonymous> (/.../yo.js:4:13)
    at Module._compile (module.js:569:30)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:503:32)
    at tryModuleLoad (module.js:466:12)
    at Function.Module._load (module.js:458:3)
```

## Solution

Add missing import.

## Comment

Happy to add a test for this that triggers such error if you think it would be worthwhile.